### PR TITLE
prometheus-configmanager helm chart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ executors:
 orbs:
   docker: circleci/docker@1.0.0
   go: circleci/go@1.1.0
+  helm: circleci/helm@0.2.3
 
 commands:
 
@@ -30,6 +31,18 @@ commands:
       - go/load-cache
       - go/mod-download
       - go/save-cache
+
+  helm-lint:
+    parameters:
+      chart:
+        type: string
+      working_directory:
+        type: string
+    steps:
+      - run:
+          name: Lint <<parameters.chart>> chart
+          working_directory: <<parameters.working_directory>>
+          command: helm lint --strict <<parameters.chart>>
 
 jobs:
   build:
@@ -74,9 +87,23 @@ jobs:
           command: golangci-lint run --out-format junit-xml > ~/test-results/lint.xml
       - *storetestdir
 
+  helm-lint:
+    executor: docker/docker
+    parameters:
+      working_directory:
+        default: helm
+        type: string
+    steps:
+      - checkout
+      - helm/install-helm-client
+      - helm-lint:
+          chart: prometheus-configmanager
+          working_directory: <<parameters.working_directory>>
+
 workflows:
   version: 2.1
   all:
     jobs:
       - lint
+      - helm-lint
       - build

--- a/helm/prometheus-configmanager/Chart.yaml
+++ b/helm/prometheus-configmanager/Chart.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2004-present Facebook All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+name: prometheus-configmanager
+apiVersion: v1
+version: 0.1.0
+description: Prometheus configmanager which provides an API to update prometheus and alertmanager configurations during runtime.
+keywords:
+  - prometheus
+maintainers:
+  - name: Scott Smith
+    email: smithscott@fb.com
+engine: gotpl

--- a/helm/prometheus-configmanager/templates/alertmanager-configurer.deployment.yaml
+++ b/helm/prometheus-configmanager/templates/alertmanager-configurer.deployment.yaml
@@ -1,0 +1,65 @@
+{{/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/}}
+{{- if .Values.alertmanagerConfigurer.create }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alertmanager-configurer
+  labels:
+    app.kubernetes.io/component: alertmanager-configurer
+spec:
+  replicas: {{ .Values.alertmanagerConfigurer.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: alertmanager-configurer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: alertmanager-configurer
+    spec:
+      {{- with .Values.alertmanagerConfigurer.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.alertmanagerConfigurer.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.alertmanagerConfigurer.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | trimSuffix "\n" | indent 8 }}
+      {{- end }}
+
+      volumes:
+        - name: "prometheus-config"
+        {{- with .Values.volumes.prometheusConfig.volumeSpec }}
+{{ toYaml .Values.volumes.prometheusConfig.volumeSpec | indent 10 }}
+        {{- end }}
+
+      containers:
+        - name: "alertmanager-configurer"
+          image: {{ required "alertmanagerConfigurer.image.repository must be provided" .Values.alertmanagerConfigurer.image.repository }}:{{ .Values.alertmanagerConfigurer.image.tag }}
+          imagePullPolicy: {{ .Values.alertmanagerConfigurer.image.pullPolicy }}
+          ports:
+            - containerPort: 9101
+          volumeMounts:
+            - name: "prometheus-config"
+              mountPath: /etc/configs
+          args:
+            - "-port={{ .Values.alertmanagerConfigurer.alertmanagerConfigPort }}"
+            - "-alertmanager-conf={{ .Values.alertmanagerConfigurer.alertmanagerConfPath }}"
+            - "-alertmanagerURL={{ .Values.alertmanagerConfigurer.alertmanagerURL  }}"
+            {{- if .Values.alertmanagerConfigurer.multitenantLabel }}
+            - "-multitenant-label={{ .Values.alertmanagerConfigurer.multitenantLabel }}"
+            {{- end }}
+          resources:
+{{ toYaml .Values.alertmanagerConfigurer.resources | indent 12 }}
+{{- end }}

--- a/helm/prometheus-configmanager/templates/alertmanager-configurer.service.yaml
+++ b/helm/prometheus-configmanager/templates/alertmanager-configurer.service.yaml
@@ -1,0 +1,42 @@
+{{/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree..
+*/}}
+{{- if .Values.alertmanagerConfigurer.create }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-configurer
+  labels:
+    app.kubernetes.io/component: alertmanager-configurer
+    {{- with .Values.alertmanagerConfigurer.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.alertmanagerConfigurer.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  selector:
+    app.kubernetes.io/component: alertmanager-configurer
+  type: {{ .Values.alertmanagerConfigurer.service.type }}
+  ports:
+{{- range $port := .Values.alertmanagerConfigurer.service.ports }}
+     - name: {{ $port.name }}
+       port: {{ $port.port }}
+       targetPort: {{ $port.targetPort }}
+{{- end }}
+{{- if eq .Values.alertmanagerConfigurer.service.type "LoadBalancer" }}
+  {{- if .Values.alertmanagerConfigurer.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.alertmanagerConfigurer.service.loadBalancerIP }}
+  {{- end -}}
+  {{- if .Values.alertmanagerConfigurer.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range .Values.alertmanagerConfigurer.service.loadBalancerSourceRanges }}
+  - {{ . }}
+  {{- end }}
+  {{- end -}}
+{{- end -}}
+{{- end }}

--- a/helm/prometheus-configmanager/templates/prometheus-configurer.deployment.yaml
+++ b/helm/prometheus-configmanager/templates/prometheus-configurer.deployment.yaml
@@ -1,0 +1,68 @@
+{{/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/}}
+{{- if .Values.prometheusConfigurer.create }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-configurer
+  labels:
+    app.kubernetes.io/component: prometheus-configurer
+spec:
+  replicas: {{ .Values.prometheusConfigurer.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: prometheus-configurer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: prometheus-configurer
+    spec:
+      {{- with .Values.prometheusConfigurer.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.prometheusConfigurer.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.prometheusConfigurer.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | trimSuffix "\n" | indent 8 }}
+      {{- end }}
+
+      volumes:
+        - name: "prometheus-config"
+        {{- with .Values.volumes.prometheusConfig.volumeSpec }}
+{{ toYaml .Values.volumes.prometheusConfig.volumeSpec | indent 10 }}
+        {{- end }}
+
+      containers:
+        - name: "prometheus-configurer"
+          image: {{ required "prometheusConfigurer.image.repository must be provided" .Values.prometheusConfigurer.image.repository }}:{{ .Values.prometheusConfigurer.image.tag }}
+          imagePullPolicy: {{ .Values.prometheusConfigurer.image.pullPolicy }}
+          ports:
+            - containerPort: 9100
+          volumeMounts:
+            - name: "prometheus-config"
+              mountPath: /etc/configs
+          args:
+            - "-port={{ .Values.prometheusConfigurer.prometheusConfigurerPort }}"
+            - "-rules-dir={{ .Values.prometheusConfigurer.rulesDir }}"
+            - "-prometheusURL={{ .Values.prometheusConfigurer.prometheusURL }}"
+            {{- if .Values.prometheusConfigurer.multitenantLabel }}
+            - "-multitenant-label={{ .Values.prometheusConfigurer.multitenantLabel }}"
+            {{- end }}
+            {{- if .Values.prometheusConfigurer.restrictQueries }}
+            - "-restrict-queries"
+            {{- end }}
+          resources:
+{{ toYaml .Values.prometheusConfigurer.resources | indent 12 }}
+{{- end }}

--- a/helm/prometheus-configmanager/templates/prometheus-configurer.service.yaml
+++ b/helm/prometheus-configmanager/templates/prometheus-configurer.service.yaml
@@ -1,0 +1,42 @@
+{{/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/}}
+{{- if .Values.prometheusConfigurer.create }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-configurer
+  labels:
+    app.kubernetes.io/component: prometheus-configurer
+    {{- with .Values.prometheusConfigurer.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.prometheusConfigurer.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  selector:
+    app.kubernetes.io/component: prometheus-configurer
+  type: {{ .Values.prometheusConfigurer.service.type }}
+  ports:
+{{- range $port := .Values.prometheusConfigurer.service.ports }}
+     - name: {{ $port.name }}
+       port: {{ $port.port }}
+       targetPort: {{ $port.targetPort }}
+{{- end }}
+{{- if eq .Values.prometheusConfigurer.service.type "LoadBalancer" }}
+  {{- if .Values.prometheusConfigurer.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.prometheusConfigurer.service.loadBalancerIP }}
+  {{- end -}}
+  {{- if .Values.prometheusConfigurer.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range .Values.prometheusConfigurer.service.loadBalancerSourceRanges }}
+  - {{ . }}
+  {{- end }}
+  {{- end -}}
+{{- end -}}
+{{- end }}

--- a/helm/prometheus-configmanager/values.yaml
+++ b/helm/prometheus-configmanager/values.yaml
@@ -1,0 +1,112 @@
+# Reference to one or more secrets to be used when pulling images
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+
+volumes:
+  prometheusConfig:
+    volumeSpec: {}
+      # hostPath:
+      #   path: /configs/prometheus
+      #   type: DirectoryOrCreate
+
+prometheusConfigurer:
+  # Enable/Disable chart
+  create: true
+
+  replicas: 1
+
+  prom_port: &prom_port 9100
+
+  # Metric Label used for restricting alerts per-tenant
+  multitenantLabel: ""
+
+  # Boolean to set whether to restrict alert expressions with multitenantLabel
+  restrictQueries: false
+
+  service:
+    annotations: {}
+    labels: {}
+    type: ClusterIP
+    ports:
+      - name: prom-configmanager
+        port: *prom_port
+        targetPort: *prom_port
+
+  prometheusConfigurerPort: *prom_port
+  rulesDir: "/etc/configs/alert_rules"
+  prometheusURL: "prometheus:9090"
+
+  image:
+    repository: prometheus-configurer
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+
+  # Pod affinity must be used to ensure that this pod runs on same node as prometheus
+
+  # Use the following in your values.yml file to ensure that this pod runs on the same
+  # node as prometheus:
+  affinity: {}
+  # affinity:
+  #   podAffinity:
+  #     requiredDuringSchedulingIgnoredDuringExecution:
+  #       - labelSelector:
+  #           matchExpressions:
+  #             - key: app.kubernetes.io/component
+  #               operator: In
+  #               values:
+  #                 - prometheus
+  #         topologyKey: "kubernetes.io/hostname"
+
+alertmanagerConfigurer:
+  # Enable/Disable chart
+  create: true
+
+  replicas: 1
+
+  am_port: &am_port 9091
+
+  # Metric Label used for restricting alerts per-tenant
+  multitenantLabel: ""
+
+  service:
+    annotations: {}
+    labels: {}
+    type: ClusterIP
+    ports:
+      - name: alertmanager-config
+        port: *am_port
+        targetPort: *am_port
+
+  alertmanagerConfigPort: *am_port
+  alertmanagerConfPath: "/etc/configs/alertmanager.yml"
+  alertmanagerURL: "alertmanager:9093"
+
+  image:
+    repository: alertmanager-configurer
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+
+  # Pod affinity must be used to ensure that this pod runs on same node as prometheus
+
+  # Use the following in your values.yml file to ensure that this pod runs on the same
+  # node as prometheus:
+
+  affinity: {}
+  # affinity:
+  #   podAffinity:
+  #     requiredDuringSchedulingIgnoredDuringExecution:
+  #       - labelSelector:
+  #           matchExpressions:
+  #             - key: app.kubernetes.io/component
+  #               operator: In
+  #               values:
+  #                 - prometheus
+  #         topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
Summary: Helm chart for prometheus-configmanager. Each of the two services can be enabled separately.

Differential Revision: D20804821

