### PR TITLE
Better error message on rule writing error (#1733)

### DIFF
--- a/prometheus/alert/client.go
+++ b/prometheus/alert/client.go
@@ -240,11 +240,11 @@ func (c *client) ReloadPrometheus() error {
 func (c *client) writeRuleFile(ruleFile *File, filename string) error {
 	yamlFile, err := yaml.Marshal(ruleFile)
 	if err != nil {
-		return fmt.Errorf("error writing rules file: %v\n %v", err, yamlFile)
+		return fmt.Errorf("error writing rules file: %v", err)
 	}
 	err = c.fsClient.WriteFile(filename, yamlFile, 0666)
 	if err != nil {
-		return fmt.Errorf("error writing rules file: %v\n %v", err, yamlFile)
+		return fmt.Errorf("error writing rules file: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookincubator/magma/pull/1733

This should improve the readability of the error a user receives when the rules file cannot be edited.

Current error:
https://pxl.cl/1891d

Reviewed By: Scott8440

Differential Revision: D21776139

