### PR TITLE
Add Pushover Support to AlertManager

### DIFF
--- a/alertmanager/config/receiver.go
+++ b/alertmanager/config/receiver.go
@@ -19,9 +19,10 @@ import (
 type Receiver struct {
 	Name string `yaml:"name" json:"name"`
 
-	SlackConfigs   []*SlackConfig   `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
-	WebhookConfigs []*WebhookConfig `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
-	EmailConfigs   []*EmailConfig   `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
+	SlackConfigs    []*SlackConfig    `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
+	WebhookConfigs  []*WebhookConfig  `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
+	EmailConfigs    []*EmailConfig    `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
+	PushoverConfigs []*PushoverConfig `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
 }
 
 // Secure replaces the receiver's name with a tenantID prefix
@@ -91,6 +92,23 @@ type EmailConfig struct {
 	HTML         string            `yaml:"html,omitempty" json:"html,omitempty"`
 	Text         string            `yaml:"text,omitempty" json:"text,omitempty"`
 	RequireTLS   *bool             `yaml:"require_tls,omitempty" json:"require_tls,omitempty"`
+}
+
+// PushoverConfig uses string instead of Secret for the UserKey and Token
+// field so that it is mashaled as is instead of being obscured which is how
+// alertmanager handles secrets. Otherwise the secrets would be obscured on
+// write to the yml file, making it unusable.
+type PushoverConfig struct {
+	HTTPConfig *common.HTTPConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+
+	UserKey  string `yaml:"user_key" json:"user_key"`
+	Token    string `yaml:"token" json:"token"`
+	Title    string `yaml:"title,omitempty" json:"title,omitempty"`
+	Message  string `yaml:"message,omitempty" json:"message,omitempty"`
+	URL      string `yaml:"url,omitempty" json:"url,omitempty"`
+	Priority string `yaml:"priority,omitempty" json:"priority,omitempty"`
+	Retry    string `yaml:"retry,omitempty" json:"retry,omitempty"`
+	Expire   string `yaml:"expire,omitempty" json:"expire,omitempty"`
 }
 
 // MarshalYAML implements the yaml.Marshaler interface for EmailConfig and


### PR DESCRIPTION
Summary: This diff adds pushover support to the alertmanager. Documentation and unit tests will be added in smaller diffs in the stack.

Reviewed By: Scott8440

Differential Revision: D21831322

