### PR TITLE
Add Pushover Unit Tests and Duration Fields to AlertManager

### DIFF
--- a/alertmanager/config/receiver.go
+++ b/alertmanager/config/receiver.go
@@ -13,6 +13,8 @@ import (
 	"prometheus-configmanager/alertmanager/common"
 
 	"github.com/prometheus/alertmanager/config"
+
+	"github.com/prometheus/common/model"
 )
 
 // Receiver uses custom notifier configs to allow for marshaling of secrets.
@@ -23,6 +25,17 @@ type Receiver struct {
 	WebhookConfigs  []*WebhookConfig  `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
 	EmailConfigs    []*EmailConfig    `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
 	PushoverConfigs []*PushoverConfig `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
+}
+
+// ReceiverJSONWrapper uses custom (JSON compatible) notifier configs to allow
+// for marshaling of secrets.
+type ReceiverJSONWrapper struct {
+	Name string `yaml:"name" json:"name"`
+
+	SlackConfigs    []*SlackConfig         `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
+	WebhookConfigs  []*WebhookConfig       `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
+	EmailConfigs    []*EmailConfig         `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
+	PushoverConfigs []*PushoverJSONWrapper `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
 }
 
 // Secure replaces the receiver's name with a tenantID prefix
@@ -101,6 +114,20 @@ type EmailConfig struct {
 type PushoverConfig struct {
 	HTTPConfig *common.HTTPConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
+	UserKey  string         `yaml:"user_key" json:"user_key"`
+	Token    string         `yaml:"token" json:"token"`
+	Title    string         `yaml:"title,omitempty" json:"title,omitempty"`
+	Message  string         `yaml:"message,omitempty" json:"message,omitempty"`
+	URL      string         `yaml:"url,omitempty" json:"url,omitempty"`
+	Priority string         `yaml:"priority,omitempty" json:"priority,omitempty"`
+	Retry    model.Duration `yaml:"retry,omitempty" json:"retry,omitempty"`
+	Expire   model.Duration `yaml:"expire,omitempty" json:"expire,omitempty"`
+}
+
+// Pushover JSONWrapper
+type PushoverJSONWrapper struct {
+	HTTPConfig *common.HTTPConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+
 	UserKey  string `yaml:"user_key" json:"user_key"`
 	Token    string `yaml:"token" json:"token"`
 	Title    string `yaml:"title,omitempty" json:"title,omitempty"`
@@ -109,6 +136,47 @@ type PushoverConfig struct {
 	Priority string `yaml:"priority,omitempty" json:"priority,omitempty"`
 	Retry    string `yaml:"retry,omitempty" json:"retry,omitempty"`
 	Expire   string `yaml:"expire,omitempty" json:"expire,omitempty"`
+}
+
+// ToReceiverFmt convers the JSONWrapper object to a true Receiver object. This will
+// only be necessary when dealing with Pushover objects for the time being (due to
+// complexities surrounding JSON unmarshalling)
+func (r *ReceiverJSONWrapper) ToReceiverFmt() (Receiver, error) {
+	receiver := Receiver{
+		Name:           r.Name,
+		SlackConfigs:   r.SlackConfigs,
+		WebhookConfigs: r.WebhookConfigs,
+		EmailConfigs:   r.EmailConfigs,
+	}
+
+	for _, p := range r.PushoverConfigs {
+		pushoverConf := PushoverConfig{
+			HTTPConfig: p.HTTPConfig,
+			UserKey:    p.UserKey,
+			Token:      p.Token,
+			Title:      p.Title,
+			Message:    p.Message,
+			URL:        p.URL,
+			Priority:   p.Priority,
+		}
+		if p.Retry != "" {
+			modelRetry, err := model.ParseDuration(p.Retry)
+			if err != nil {
+				return receiver, err
+			}
+			pushoverConf.Retry = modelRetry
+		}
+		if p.Expire != "" {
+			modelExpire, err := model.ParseDuration(p.Expire)
+			if err != nil {
+				return receiver, err
+			}
+			pushoverConf.Expire = modelExpire
+		}
+		receiver.PushoverConfigs = append(receiver.PushoverConfigs, &pushoverConf)
+	}
+
+	return receiver, nil
 }
 
 // MarshalYAML implements the yaml.Marshaler interface for EmailConfig and

--- a/alertmanager/config/receiver_test.go
+++ b/alertmanager/config/receiver_test.go
@@ -39,6 +39,41 @@ func TestConfig_Validate(t *testing.T) {
 	err = invalidConfig.Validate()
 	assert.EqualError(t, err, `undefined receiver "testReceiver" used in route`)
 
+	invalidPushoverReceiverJSON := config.PushoverJSONWrapper{
+		UserKey: "0",
+		Token:   "0",
+		Expire:  "1m1s",
+	}
+	invalidPushoverReceiverWrapper := config.ReceiverJSONWrapper{
+		Name:            "invalidPushover",
+		PushoverConfigs: []*config.PushoverJSONWrapper{&invalidPushoverReceiverJSON},
+	}
+
+	_, err = invalidPushoverReceiverWrapper.ToReceiverFmt()
+	assert.EqualError(t, err, `not a valid duration string: "1m1s"`)
+
+	validPushoverReceiverJSON := config.PushoverJSONWrapper{
+		UserKey: "0",
+		Token:   "0",
+		Expire:  "1m",
+	}
+	validPushoverWrapper := config.ReceiverJSONWrapper{
+		Name:            "validPushover",
+		PushoverConfigs: []*config.PushoverJSONWrapper{&validPushoverReceiverJSON},
+	}
+	validPushoverReceiver, err := validPushoverWrapper.ToReceiverFmt()
+	assert.NoError(t, err)
+
+	validPushoverConfig := config.Config{
+		Route: &config.Route{
+			Receiver: "validPushover",
+		},
+		Receivers: []*config.Receiver{&validPushoverReceiver},
+		Global:    &defaultGlobalConf,
+	}
+	err = validPushoverConfig.Validate()
+	assert.NoError(t, err)
+
 	invalidSlackReceiver := config.Receiver{
 		Name: "invalidSlack",
 		SlackConfigs: []*config.SlackConfig{
@@ -89,6 +124,9 @@ func TestConfig_GetReceiver(t *testing.T) {
 	assert.NotNil(t, rec)
 
 	rec = tc.SampleConfig.GetReceiver("email_receiver")
+	assert.NotNil(t, rec)
+
+	rec = tc.SampleConfig.GetReceiver("pushover_receiver")
 	assert.NotNil(t, rec)
 
 	rec = tc.SampleConfig.GetReceiver("nonRoute")

--- a/alertmanager/handlers/handlers.go
+++ b/alertmanager/handlers/handlers.go
@@ -276,10 +276,18 @@ func decodeReceiverPostRequest(c echo.Context) (config.Receiver, error) {
 	}
 	receiver := config.Receiver{}
 	err = json.Unmarshal(body, &receiver)
-	if err != nil {
-		return config.Receiver{}, fmt.Errorf("error unmarshalling payload: %v", err)
+	if err == nil {
+		return receiver, nil
 	}
-	return receiver, nil
+
+	// Try to unmarshal into the ReceiverJSONWrapper struct if prometheus struct doesn't work
+	jsonPayload := config.ReceiverJSONWrapper{}
+	err = json.Unmarshal(body, &jsonPayload)
+	if err != nil {
+		return receiver, fmt.Errorf("error unmarshalling payload: %v", err)
+	}
+
+	return jsonPayload.ToReceiverFmt()
 }
 
 func decodeRoutePostRequest(c echo.Context) (config.Route, error) {

--- a/alertmanager/handlers/handlers_test.go
+++ b/alertmanager/handlers/handlers_test.go
@@ -366,7 +366,7 @@ func TestDecodeReceiverPostRequest(t *testing.T) {
 		Name bool `json:"name"`
 	}{false}, http.MethodPost, "/", v1receiverPath, testNID)
 	_, err = decodeReceiverPostRequest(c)
-	assert.EqualError(t, err, `error unmarshalling payload: json: cannot unmarshal bool into Go struct field Receiver.name of type string`)
+	assert.EqualError(t, err, `error unmarshalling payload: json: cannot unmarshal bool into Go struct field ReceiverJSONWrapper.name of type string`)
 }
 
 func TestDecodeRoutePostRequest(t *testing.T) {

--- a/alertmanager/test_common/configs.go
+++ b/alertmanager/test_common/configs.go
@@ -39,6 +39,13 @@ var (
 			Channel:  "slack_alert_channel",
 		}},
 	}
+	SamplePushoverReceiver = config.Receiver{
+		Name: "pushover_receiver",
+		PushoverConfigs: []*config.PushoverConfig{{
+			UserKey: "101",
+			Token:   "0",
+		}},
+	}
 	SampleWebhookReceiver = config.Receiver{
 		Name: "webhook_receiver",
 		WebhookConfigs: []*config.WebhookConfig{{
@@ -62,7 +69,7 @@ var (
 	SampleConfig = config.Config{
 		Route: &SampleRoute,
 		Receivers: []*config.Receiver{
-			&SampleSlackReceiver, &SampleReceiver, &SampleWebhookReceiver, &SampleEmailReceiver,
+			&SampleSlackReceiver, &SampleReceiver, &SamplePushoverReceiver, &SampleWebhookReceiver, &SampleEmailReceiver,
 		},
 	}
 )


### PR DESCRIPTION
Summary:
This diff adds unit test support for pushover on AlertManager.

Also adds duration fields for the Expire and Retry fields of the pushover.

Documentation updates will be the last in this chain of commits.

Reviewed By: Scott8440

Differential Revision: D21844124

