### PR TITLE
Add PagerDuty Support to AlertManager (#1767)

### DIFF
--- a/alertmanager/config/receiver.go
+++ b/alertmanager/config/receiver.go
@@ -21,10 +21,11 @@ import (
 type Receiver struct {
 	Name string `yaml:"name" json:"name"`
 
-	SlackConfigs    []*SlackConfig    `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
-	WebhookConfigs  []*WebhookConfig  `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
-	EmailConfigs    []*EmailConfig    `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
-	PushoverConfigs []*PushoverConfig `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
+	SlackConfigs     []*SlackConfig     `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
+	WebhookConfigs   []*WebhookConfig   `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
+	EmailConfigs     []*EmailConfig     `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
+	PagerDutyConfigs []*PagerDutyConfig `yaml:"pagerduty_configs,omitempty" json:"pagerduty_configs,omitempty"`
+	PushoverConfigs  []*PushoverConfig  `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
 }
 
 // ReceiverJSONWrapper uses custom (JSON compatible) notifier configs to allow
@@ -32,10 +33,11 @@ type Receiver struct {
 type ReceiverJSONWrapper struct {
 	Name string `yaml:"name" json:"name"`
 
-	SlackConfigs    []*SlackConfig         `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
-	WebhookConfigs  []*WebhookConfig       `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
-	EmailConfigs    []*EmailConfig         `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
-	PushoverConfigs []*PushoverJSONWrapper `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
+	SlackConfigs     []*SlackConfig         `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
+	WebhookConfigs   []*WebhookConfig       `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
+	EmailConfigs     []*EmailConfig         `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
+	PagerDutyConfigs []*PagerDutyConfig     `yaml:"pagerduty_configs,omitempty" json:"pagerduty_configs,omitempty"`
+	PushoverConfigs  []*PushoverJSONWrapper `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
 }
 
 // Secure replaces the receiver's name with a tenantID prefix
@@ -107,6 +109,25 @@ type EmailConfig struct {
 	RequireTLS   *bool             `yaml:"require_tls,omitempty" json:"require_tls,omitempty"`
 }
 
+// PagerDutyConfig uses string instead of Secret for the RoutingKey and ServiceKey
+// field so that it is mashaled as is instead of being obscured which is how
+// alertmanager handles secrets. Otherwise the secrets would be obscured on
+// write to the yml file, making it unusable.
+type PagerDutyConfig struct {
+	HTTPConfig *common.HTTPConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+
+	RoutingKey  string                   `yaml:"routing_key,omitempty" json:"routing_key,omitempty"`
+	ServiceKey  string                   `yaml:"service_key,omitempty" json:"service_key,omitempty"`
+	URL         string                   `yaml:"url,omitempty" json:"url,omitempty"`
+	Client      string                   `yaml:"client,omitempty" json:"client,omitempty"`
+	ClientURL   string                   `yaml:"client_url,omitempty" json:"client_url,omitempty"`
+	Description string                   `yaml:"description,omitempty" json:"description,omitempty"`
+	Severity    string                   `yaml:"severity,omitempty" json:"severity,omitempty"`
+	Details     map[string]string        `yaml:"details,omitempty" json:"details,omitempty"`
+	Images      []*config.PagerdutyImage `yaml:"images,omitempty" json:"images,omitempty"`
+	Links       []*config.PagerdutyLink  `yaml:"links,omitempty" json:"links,omitempty"`
+}
+
 // PushoverConfig uses string instead of Secret for the UserKey and Token
 // field so that it is mashaled as is instead of being obscured which is how
 // alertmanager handles secrets. Otherwise the secrets would be obscured on
@@ -143,10 +164,11 @@ type PushoverJSONWrapper struct {
 // complexities surrounding JSON unmarshalling)
 func (r *ReceiverJSONWrapper) ToReceiverFmt() (Receiver, error) {
 	receiver := Receiver{
-		Name:           r.Name,
-		SlackConfigs:   r.SlackConfigs,
-		WebhookConfigs: r.WebhookConfigs,
-		EmailConfigs:   r.EmailConfigs,
+		Name:             r.Name,
+		SlackConfigs:     r.SlackConfigs,
+		WebhookConfigs:   r.WebhookConfigs,
+		EmailConfigs:     r.EmailConfigs,
+		PagerDutyConfigs: r.PagerDutyConfigs,
 	}
 
 	for _, p := range r.PushoverConfigs {

--- a/alertmanager/config/receiver_test.go
+++ b/alertmanager/config/receiver_test.go
@@ -111,6 +111,23 @@ func TestConfig_Validate(t *testing.T) {
 	}
 	err = invalidSlackAction.Validate()
 	assert.EqualError(t, err, `missing type in Slack action configuration`)
+
+	// Fail if pager duty contains no ServiceKey or RoutingKey
+	invalidPagerDuty := config.Config{
+		Route: &config.Route{
+			Receiver: "invalidPagerDuty",
+		},
+		Receivers: []*config.Receiver{{
+			Name: "invalidPagerDuty",
+			PagerDutyConfigs: []*config.PagerDutyConfig{{
+				Links: []*amconfig.PagerdutyLink{{
+					Text: "test",
+				}},
+			}},
+		}},
+	}
+	err = invalidPagerDuty.Validate()
+	assert.EqualError(t, err, `missing service or routing key in PagerDuty config`)
 }
 
 func TestConfig_GetReceiver(t *testing.T) {
@@ -124,6 +141,9 @@ func TestConfig_GetReceiver(t *testing.T) {
 	assert.NotNil(t, rec)
 
 	rec = tc.SampleConfig.GetReceiver("email_receiver")
+	assert.NotNil(t, rec)
+
+	rec = tc.SampleConfig.GetReceiver("pagerduty_receiver")
 	assert.NotNil(t, rec)
 
 	rec = tc.SampleConfig.GetReceiver("pushover_receiver")

--- a/alertmanager/docs/swagger-v1.yml
+++ b/alertmanager/docs/swagger-v1.yml
@@ -175,6 +175,10 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/slack_receiver'
+      pagerduty_configs:
+        type: array
+        items:
+          $ref: '#/definitions/pagerduty_receiver'
       pushover_configs:
         type: array
         items:
@@ -278,6 +282,59 @@ definitions:
       ok_text:
         type: string
       dismiss_text:
+        type: string
+
+  pagerduty_receiver:
+    type: object
+    required:
+      - service_key
+      - routing_key
+    properties:
+      http_config:
+        $ref: '#/definitions/http_config'
+      routing_key:
+        type: string
+      service_key:
+        type: string
+      url:
+        type: string
+      client:
+        type: string
+      client_url:
+        type: string
+      description:
+        type: string
+      severity:
+        type: string
+      details:
+        type: object
+        additionalProperties:
+          type: string
+      images:
+        type: array
+        items:
+          $ref: '#/definitions/pagerduty_images'
+      links:
+        type: array
+        items:
+          $ref: '#/definitions/pagerduty_links'
+
+  pagerduty_images:
+    type: object
+    properties:
+      src:
+        type: string
+      alt:
+        type: string
+      text:
+        type: string
+
+  pagerduty_links:
+    type: object
+    properties:
+      href:
+        type: string
+      text:
         type: string
 
   pushover_receiver:

--- a/alertmanager/test_common/configs.go
+++ b/alertmanager/test_common/configs.go
@@ -39,6 +39,12 @@ var (
 			Channel:  "slack_alert_channel",
 		}},
 	}
+	SamplePagerDutyReceiver = config.Receiver{
+		Name: "pagerduty_receiver",
+		PagerDutyConfigs: []*config.PagerDutyConfig{{
+			ServiceKey: "0",
+		}},
+	}
 	SamplePushoverReceiver = config.Receiver{
 		Name: "pushover_receiver",
 		PushoverConfigs: []*config.PushoverConfig{{
@@ -69,7 +75,7 @@ var (
 	SampleConfig = config.Config{
 		Route: &SampleRoute,
 		Receivers: []*config.Receiver{
-			&SampleSlackReceiver, &SampleReceiver, &SamplePushoverReceiver, &SampleWebhookReceiver, &SampleEmailReceiver,
+			&SampleSlackReceiver, &SampleReceiver, &SamplePagerDutyReceiver, &SamplePushoverReceiver, &SampleWebhookReceiver, &SampleEmailReceiver,
 		},
 	}
 )


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookincubator/magma/pull/1767

This diff provides the functionality to use PagerDuty with AlertManager, in addition to unit testing and documentation for the new feature.

Note: this did not have any strange fields like the duration field for the PushoverConfig. I used existing fields for the images and links fields (in the prometheus config), as all the underlying structures were string, and no modification was required.

Reviewed By: Scott8440

Differential Revision: D21871913

