### PR TITLE
Allow "requireTLS" field in email receiver configs

### DIFF
--- a/alertmanager/config/receiver.go
+++ b/alertmanager/config/receiver.go
@@ -200,15 +200,6 @@ func (r *ReceiverJSONWrapper) ToReceiverFmt() (Receiver, error) {
 	return receiver, nil
 }
 
-// MarshalYAML implements the yaml.Marshaler interface for EmailConfig and
-// forces RequireTLS to be false. RequireTLS must be false since we don't support
-// storing certificate files.
-func (e EmailConfig) MarshalYAML() (interface{}, error) {
-	valFalse := false
-	e.RequireTLS = &valFalse
-	return e, nil
-}
-
 // WebhookConfig is a copy of prometheus/alertmanager/config.WebhookConfig with
 // alertmanager-configurer's custom HTTPConfig
 type WebhookConfig struct {

--- a/alertmanager/config/receiver_test.go
+++ b/alertmanager/config/receiver_test.go
@@ -179,8 +179,6 @@ func TestReceiver_Unsecure(t *testing.T) {
 	assert.Equal(t, "receiverName", rec.Name)
 }
 
-// TestMarshalYamlEmailConfig checks that all EmailConfigs are marshaled with
-// requireTLS set to false
 func TestMarshalYamlEmailConfig(t *testing.T) {
 	valTrue := true
 	emailConf := config.EmailConfig{
@@ -190,6 +188,5 @@ func TestMarshalYamlEmailConfig(t *testing.T) {
 	}
 	ymlData, err := yaml.Marshal(emailConf)
 	assert.NoError(t, err)
-	assert.True(t, strings.Contains(string(ymlData), "require_tls: false"))
-	assert.False(t, strings.Contains(string(ymlData), "require_tls: true"))
+	assert.True(t, strings.Contains(string(ymlData), "require_tls: true"))
 }


### PR DESCRIPTION
Summary: `requireTLS` field just specifies whether the smtp server needs TLS or not. I had originally restricted this field because I thought it would require support for the whole TLS config, but that doesn't seem to be the case.

Reviewed By: aclave1

Differential Revision: D23719429

