### PR TITLE
Support week and day in rule durations

### DIFF
--- a/prometheus/alert/client.go
+++ b/prometheus/alert/client.go
@@ -10,10 +10,11 @@ package alert
 import (
 	"bytes"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"io/ioutil"
 	"net/http"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/facebookincubator/prometheus-configmanager/fsclient"
 

--- a/prometheus/handlers/handlers.go
+++ b/prometheus/handlers/handlers.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"time"
 
 	"github.com/facebookincubator/prometheus-configmanager/prometheus/alert"
 
@@ -295,15 +294,11 @@ func rulesToJSON(rules []rulefmt.Rule) ([]alert.RuleJSONWrapper, error) {
 }
 
 func rulefmtToJSON(rule rulefmt.Rule) (*alert.RuleJSONWrapper, error) {
-	duration, err := time.ParseDuration(rule.For.String())
-	if err != nil {
-		return nil, err
-	}
 	return &alert.RuleJSONWrapper{
 		Record:      rule.Record,
 		Alert:       rule.Alert,
 		Expr:        rule.Expr,
-		For:         duration.String(),
+		For:         rule.For.String(),
 		Labels:      rule.Labels,
 		Annotations: rule.Annotations,
 	}, nil


### PR DESCRIPTION
Summary: Reads were failing when a rule duration was manually configured with "w" and "d" (weeks and days). This should theoretically work even though there isn't an option in the UI to do that yet. The cause was converting from prometheus' `model.Duration` to the built-in `time.Duration` when building the JSON to return in the request. Turns out `model.Duration` also has a string() function we can use, so just use that instead. buit-in time doesn't handle w/d which was the problem.

Differential Revision: D25450686

