### PR TITLE
delete routes referencing receiver when receiver deleted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 yarn-error.log
 **/.env
 coverage
+.idea/

--- a/alertmanager/client/client_test.go
+++ b/alertmanager/client/client_test.go
@@ -240,7 +240,14 @@ func newTestClient() (AlertmanagerClient, *mocks.FSClient, *[]byte) {
 	tenancy := &alert.TenancyConfig{
 		RestrictorLabel: "tenantID",
 	}
-	return NewClient("test/alertmanager.yml", "alertmanager-host:9093", tenancy, fsClient), fsClient, &outputFile
+	conf := ClientConfig{
+		ConfigPath:      "test/alertmanager.yml",
+		AlertmanagerURL: "alertmanager-host:9093",
+		FsClient:        fsClient,
+		Tenancy:         tenancy,
+		DeleteRoutes:    false,
+	}
+	return NewClient(conf), fsClient, &outputFile
 }
 
 func byteToConfig(in []byte) (config.Config, error) {

--- a/alertmanager/config/config_test.go
+++ b/alertmanager/config/config_test.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testConfig = Config{
+		Global:       nil,
+		Route:        &Route{
+			Receiver:       "base",
+			Routes:         []*Route{
+				{Receiver: "testReceiver"},
+				{Receiver: "testReceiver2"},
+				{
+					Receiver: "testReceiver3",
+					Routes: []*Route{
+						{Receiver: "testReceiver"},
+						{Receiver: "testReceiverChild1"},
+					},
+				},
+			},
+		},
+		Receivers:    []*Receiver{{
+			Name:             "testReceiver",
+		}},
+	}
+)
+
+func TestConfig_RemoveReceiverFromRoute(t *testing.T) {
+	copy := testConfig
+	copy.RemoveReceiverFromRoute("testReceiver")
+	assert.Len(t, copy.Route.Routes, 2)
+	assert.Equal(t, copy.Route.Routes[0].Receiver, "testReceiver2")
+	assert.Equal(t, copy.Route.Routes[1].Receiver, "testReceiver3")
+
+	assert.Len(t, copy.Route.Routes[1].Routes, 1)
+	assert.Equal(t, copy.Route.Routes[1].Routes[0].Receiver, "testReceiverChild1")
+}
+
+func TestConfig_SearchRoutesForReceiver(t *testing.T) {
+	assert.True(t, testConfig.SearchRoutesForReceiver("base"))
+	assert.True(t, testConfig.SearchRoutesForReceiver("testReceiver2"))
+	assert.True(t, testConfig.SearchRoutesForReceiver("testReceiver3"))
+	assert.True(t, testConfig.SearchRoutesForReceiver("testReceiverChild1"))
+	assert.False(t, testConfig.SearchRoutesForReceiver("foo"))
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - '-alertmanagerURL=alertmanager:9093'
       - '-multitenant-label=tenant'
       - '-template-directory=/etc/configs/templates'
+      - '-delete-route-with-receiver=true'
     volumes:
       - ./default_configs:/etc/configs
     ports:


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

Magma was running into issues in the NMS when trying to delete receivers. This happened because the configmanager did not check for references to the deleted receiver in routes. When the receiver was deleted, the route reference still existed, so alertmanager was unable to load the new config.

This solves the problem in two ways. First, a cmd line flag to determine behavior by default will just show an error if you try to delete a receiver that is still referenced in routes. If that flag is enabled, all routes which send to that receiver are deleted when you delete the receiver. This works best for magma nms since the route tree is very simple, and there wouldn't be any negative consequences from deleting these routes.

Tested with new unit tests, and spinning up the compose file and through the UI adding receivers, hooking alert rules to them, then deleting the receiver under both flag conditions to see expected behavior occurs.