### PR TITLE
upgrade helm circleci orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ executors:
 orbs:
   docker: circleci/docker@1.0.0
   go: circleci/go@1.1.0
-  helm: circleci/helm@0.2.3
+  helm: circleci/helm@1.2.0
 
 commands:
 


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

CircleCI was failing because the orb used to run helm-lint was old and no longer works due to changes in public helm chart repositories.

Upgrade the helm version and helm-lint works.