### PR TITLE
increase logging

### DIFF
--- a/alertmanager/server.go
+++ b/alertmanager/server.go
@@ -48,6 +48,7 @@ func main() {
 
 	e := echo.New()
 	e.Use(middleware.CORS())
+	e.Use(middleware.Logger())
 
 	fileLocks, err := alert.NewFileLocker(alert.NewDirectoryClient(*templateDirPath))
 	if err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - '-port=9100'
       - '-rules-dir=/etc/configs/alert_rules'
       - '-prometheusURL=prometheus:9090'
+      - '-stderrthreshold=INFO'
     volumes:
       - ./default_configs:/etc/configs
     ports:
@@ -31,6 +32,7 @@ services:
       - '-multitenant-label=tenant'
       - '-template-directory=/etc/configs/templates'
       - '-delete-route-with-receiver=true'
+      - '-stderrthreshold=INFO'
     volumes:
       - ./default_configs:/etc/configs
     ports:

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/labstack/echo v0.0.0-20181123063414-c54d9e8eed6c
 	github.com/labstack/gommon v0.2.8 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/alertmanager v0.21.0
 	github.com/prometheus/common v0.11.1
 	github.com/prometheus/prometheus v1.8.2-0.20200819132913-cb830b0a9c78

--- a/prometheus/alert/client_test.go
+++ b/prometheus/alert/client_test.go
@@ -73,10 +73,8 @@ var (
 	}
 )
 
-func TestClient_ValidateRule(t *testing.T) {
-	client := newTestClient("tenantID")
-
-	err := client.ValidateRule(sampleRule)
+func TestValidateRule(t *testing.T) {
+	err := alert.ValidateRule(sampleRule)
 	assert.NoError(t, err)
 
 	invalidRule := rulefmt.Rule{
@@ -84,7 +82,7 @@ func TestClient_ValidateRule(t *testing.T) {
 		Record: "x",
 		Alert:  "x",
 	}
-	err = client.ValidateRule(invalidRule)
+	err = alert.ValidateRule(invalidRule)
 	assert.Error(t, err)
 }
 func TestClient_RuleExists(t *testing.T) {

--- a/prometheus/server.go
+++ b/prometheus/server.go
@@ -66,6 +66,7 @@ func main() {
 
 	e := echo.New()
 	e.Use(middleware.CORS())
+	e.Use(middleware.Logger())
 
 	handlers.RegisterBaseHandlers(e)
 	handlers.RegisterV0Handlers(e, alertClient)


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>
## Summary:
Logging was very light on the configmanagers, which made debugging hard. This diff adds request logging so all requests are recorded, as well as logging of the details of each request (e.g. the rule configuration).
Additionally adds a bit of logic to make better error responses on invalid rule configurations, so the caller will know exactly what is wrong about their request's payload.

## Test Plan:
Example Logs:
```
am-configurer      | I0208 19:45:59.360588       1 server.go:72] Alertmanager Config server listening on port: 9101
am-configurer      |
am-configurer      |    ____    __
am-configurer      |   / __/___/ /  ___
am-configurer      |  / _// __/ _ \/ _ \
am-configurer      | /___/\__/_//_/\___/ v3.3.dev
am-configurer      | High performance, minimalist Go web framework
am-configurer      | https://echo.labstack.com
am-configurer      | ____________________________________O/_______
am-configurer      |                                     O\
am-configurer      | ⇨ http server started on [::]:9101
am-configurer      | I0208 19:58:01.494313       1 handlers.go:176] Get Receiver: Tenant: default, receiver:
am-configurer      | {"time":"2021-02-08T19:58:01.5088881Z","id":"","remote_ip":"172.18.0.1","host":"localhost:9101","method":"GET","uri":"/v1/default/receiver","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36","status":200,"error":"","latency":14408600","latency_human":"14.4086ms","bytes_in":0,"bytes_out":2}
am-configurer      | I0208 19:58:08.144937       1 handlers.go:154] Configure Receiver: Tenant: default, receiver: {Name:test SlackConfigs:[] WebhookConfigs:[] EmailConfigs:[] PagerDutyConfigs:[] PushoverConfigs:[]}
am-configurer      | {"time":"2021-02-08T19:58:08.2018724Z","id":"","remote_ip":"172.18.0.1","host":"localhost:9101","method":"POST","uri":"/v1/default/receiver","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36","status":200,"error":"","latency":57089000","latency_human":"57.089ms","bytes_in":15,"bytes_out":0}
am-configurer      | I0208 19:58:08.290363       1 handlers.go:176] Get Receiver: Tenant: default, receiver:
am-configurer      | {"time":"2021-02-08T19:58:08.2974143Z","id":"","remote_ip":"172.18.0.1","host":"localhost:9101","method":"GET","uri":"/v1/default/receiver","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36","status":200,"error":"","latency":7055200","latency_human":"7.0552ms","bytes_in":0,"bytes_out":17}
```